### PR TITLE
use bundled assets for session live view

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -16,8 +16,11 @@ export async function POST() {
 
     return NextResponse.json({
       sessionId: session.id,
-      debugUrl: debugUrl.debuggerFullscreenUrl,
-      region: "us-east-1"
+      debugUrl: debugUrl.debuggerFullscreenUrl.replace(
+        "https://www.browserbase.com/devtools-fullscreen/inspector.html",
+        "https://www.browserbase.com/devtools-internal-compiled/index.html"
+      ),
+      region: "us-east-1",
     });
   } catch (error) {
     console.error("Error creating session:", error);


### PR DESCRIPTION
rendering the session live view results in thousands of requests to www.browserbase.com. doing this two, three, four times can result in tens of thousands of requests. let's use the bundled version instead to reduce the number of requests. the demo route for the browserbase homepage already does this: https://github.com/browserbase/core/blob/8baf6decc368af338265cb68cb924bef0ac5a90e/apps/core/src/app/demo/get-live-url/route.ts#L28-L39