### PR TITLE
fix: adding browserbase packages to external next packages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: ["@browserbasehq/stagehand", "@browserbasehq/sdk"],
   images: {
     domains: ['imgflip.com', 'i.imgflip.com'],
     remotePatterns: [


### PR DESCRIPTION
# what

getting constructor errors when running /chat route due to stagehand & bb packages not being bundled properly